### PR TITLE
Make NoPager actually not invoke a pager

### DIFF
--- a/portable.py
+++ b/portable.py
@@ -273,8 +273,8 @@ def RunWindowsPager(cmd):
   pager.active = True
 
 def NoPager(cmd):
-  if not isUnix():
-    RunWindowsShell(cmd)
+  return
+    
 
 def RunWindowsShell(cmd):
   executable = _SelectCatenate(cmd.manifest.globalConfig)


### PR DESCRIPTION
On windows10 in CMD and PowerShell the --no-pager switch didn't work as it would try to use 'cat'. This change makes the NoPager code not invoke a pager instead.